### PR TITLE
feat: プロジェクト個別化 - テンプレートから実プロジェクトへの適用 #4

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,33 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: ref-q-developer
+  description: Amazon Q Developer Reference Implementation
+  labels:
+    category: project
+    release: stable
+    environment: dev
+  tags:
+    - java
+    - python
+    - nodejs
+    - react
+    - typescript
+    - amplify
+    - amazon-q
+  annotations:
+    github.com/project-slug: irahara-ambient/ref-q-developer-prs
+    backstage.io/techdocs-ref: dir:.
+    backstage.io/source-template: template:default/tmpl-amplify
+spec:
+  type: service
+  system: system:default/internal-developer-platform
+  owner: group:default/pe-ld
+  dependsOn:
+    - group:default/pe-ld
+    - group:default/tmc-pe
+    - component:tmpl-amplify
+    - group:default/pe-po
+    - group:default/pe-dev
+  subcomponentOf: tmpl-amplify
+  lifecycle: experimental


### PR DESCRIPTION
## Overview

✨ テンプレートから実プロジェクトへの個別化設定

テンプレートリポジトリから派生した実プロジェクトとして、プロジェクト固有の情報を設定し、Backstageカタログに登録可能な状態にします。

## Enhancement

🚀 主な個別化内容

### プロジェクト個別化

- Backstageカタログ情報の設定
- プロジェクト固有メタデータの追加
- テンプレート参照情報の明記

#### カタログ情報

### ファイル構成

```bash
catalog-info.yaml:
├── metadata
│   ├── name: ref-q-developer
│   ├── description: Amazon Q Developer Reference Implementation
│   ├── tags: amazon-q追加
│   └── annotations
│       ├── github.com/project-slug: irahara-ambient/ref-q-developer-prs
│       └── backstage.io/source-template: template:default/tmpl-amplify
└── spec
    ├── type: service
    ├── owner: group:default/pe-ld
    └── lifecycle: experimental
```

### 技術的特徴

- Backstageカタログとの統合
- プロジェクト識別情報の明確化
- テンプレート継承関係の可視化
- Amazon Q Developerタグの追加

### 今回の実装範囲

- catalog-info.yamlの完全設定
- プロジェクト固有情報の定義
- テンプレート参照情報の追加

### 今後の課題

- プロジェクトドキュメントの整備
- 依存関係の詳細化
- ライフサイクル管理の検討